### PR TITLE
with_context_fields_fix починил ошибку с игнорированием мутации полей

### DIFF
--- a/app/pkg/logging/logging.go
+++ b/app/pkg/logging/logging.go
@@ -77,17 +77,18 @@ func (z *ZapLogger) Sync() {
 }
 
 func (z *ZapLogger) withCtxFields(ctx context.Context, fields ...zap.Field) []zap.Field {
+	var mrgdFields ZapFields
 	ctxFields, ok := ctx.Value(zapFieldsKey).(ZapFields)
 	if ok {
-		ctxFields.Append(fields...)
+		mrgdFields = ctxFields.Append(fields...)
 	} else {
 		ctxFields = make(ZapFields)
-		ctxFields.Append(fields...)
+		mrgdFields = ctxFields.Append(fields...)
 	}
 
-	maskedFields := make([]zap.Field, 0, len(fields))
+	maskedFields := make([]zap.Field, 0, len(mrgdFields))
 
-	for _, f := range ctxFields {
+	for _, f := range mrgdFields {
 		maskedFields = append(maskedFields, z.maskField(f))
 	}
 


### PR DESCRIPTION
`with_context_fields` не сохраняет результат выполнения Append, поэтому аргументы`fields ...zap.Field` не логируются 

До
```
lg.InfoCtx(ctx, "config", zap.String("fiz", "baz"))
=> 
{"level":"INFO","@timestamp":"2025-01-04T15:06:56.802+0300","caller":"agent/main.go:22","message":"config"}
```

После
```
lg.InfoCtx(ctx, "config", zap.String("fiz", "baz"))
=>
{"level":"INFO","@timestamp":"2025-01-04T15:34:55.173+0300","caller":"agent/main.go:22","message":"config","fiz":"baz"}
```